### PR TITLE
Fix misspelled __IL2CPP_METADATA_VERISON macro in helpers

### DIFF
--- a/Il2CppInspector.Common/Properties/Resources.resx
+++ b/Il2CppInspector.Common/Properties/Resources.resx
@@ -281,7 +281,7 @@ app::String* ToString(app::Object_1* Object);
 
 // Helper function to check if a metadata usage pointer is initialized
 template&lt;typename T&gt; bool il2cppi_is_initialized(T* metadataItem) {
-#if __IL2CPP_METADATA_VERISON &lt; 270
+#if __IL2CPP_METADATA_VERSION &lt; 270
  return *metadataItem != 0;
 #else
  // Metadata &gt;=27 (Unity 2020.2)


### PR DESCRIPTION
Small typo fix:  in the C++ helper template (Resources.resx, the il2cppi_is_initialized helper), the metadata-version check reads:
`#if __IL2CPP_METADATA_VERISON < 270`

The macro name is misspelled (VERISON). Since that name is never defined, the #if always evaluates to 0 < 270 = true, so il2cppi_is_initialized() always takes the old pre-v27 branch even on newer metadata, where it should take the `& 1` branch.

So, I fixed the spelling to `__IL2CPP_METADATA_VERSION`.