### PR TITLE
Fix malformed .sln/.vcxproj generated by the CLI (empty name, unsubstituted tokens)

### DIFF
--- a/Il2CppInspector.Common/Outputs/CppScaffolding.cs
+++ b/Il2CppInspector.Common/Outputs/CppScaffolding.cs
@@ -344,10 +344,11 @@ namespace Il2CppInspector.Outputs
 
             // Write Visual Studio project and solution files
             var projectGuid = Guid.NewGuid();
-            var projectFile = projectName + ".vcxproj";
+            var projectFile = sanitizedProjectName + ".vcxproj";
 
             WriteIfNotExists(Path.Combine(projectPath, projectFile),
-                Resources.CppProjTemplate.Replace("%PROJECTGUID%", projectGuid.ToString()));
+                Resources.CppProjTemplate.Replace("%PROJECTGUID%", projectGuid.ToString())
+                    .Replace("%PROJECTNAME%", sanitizedProjectName));
 
             var guid1 = Guid.NewGuid();
             var guid2 = Guid.NewGuid();
@@ -382,7 +383,7 @@ namespace Il2CppInspector.Outputs
 
             var sln = Resources.CppSlnTemplate
                 .Replace("%PROJECTGUID%", projectGuid.ToString())
-                .Replace("%PROJECTNAME%", projectName)
+                .Replace("%PROJECTNAME%", sanitizedProjectName)
                 .Replace("%PROJECTFILE%", projectFile)
                 .Replace("%SOLUTIONGUID%", solutionGuid.ToString());
 

--- a/Il2CppInspector.Common/Properties/Resources.resx
+++ b/Il2CppInspector.Common/Properties/Resources.resx
@@ -528,8 +528,8 @@ DWORD WINAPI UnloadWatcherThread(LPVOID lpParam)
       &lt;PropertyGroup Label="Globals"&gt;
       &lt;!--&lt;VCProjectVersion&gt;16.0&lt;/VCProjectVersion&gt;--&gt;
       &lt;Keyword&gt;Win32Proj&lt;/Keyword&gt;
-      &lt;ProjectGuid&gt;{%PROJECTGUID}&lt;/ProjectGuid&gt;
-    &lt;RootNamespace&gt;{%PROJECTNAME}&lt;/RootNamespace&gt;
+      &lt;ProjectGuid&gt;{%PROJECTGUID%}&lt;/ProjectGuid&gt;
+    &lt;RootNamespace&gt;%PROJECTNAME%&lt;/RootNamespace&gt;
     &lt;!--&lt;WindowsTargetPlatformVersion&gt;10.0&lt;/WindowsTargetPlatformVersion&gt;--&gt;
   &lt;/PropertyGroup&gt;
   &lt;Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" /&gt;


### PR DESCRIPTION
Generating the C++ scaffolding from the CLI (--cpp-out) emits a solution that won't open in Visual Studio ("the selected file is a solution file, but appears to be corrupted"). 

Two causes:
1. Null project name. The CLI calls CppScaffolding.Write(path) with no projectName (Program.cs), so it's null. The method computes a correct fallback (sanitizedProjectName = "Il2CppDll") but then uses the raw null projectName for the .vcxproj filename (-> ".vcxproj", empty base) and the .sln %PROJECTNAME% replacement (Replace with null removes it -> empty name), so the Project line becomes `... = "", ".vcxproj", "{guid}"`.
2. Mismatched .vcxproj template tokens. CppProjTemplate uses {%PROJECTGUID} and {%PROJECTNAME} (no trailing %), but the code substitutes %PROJECTGUID%, so those tokens are never replaced and survive literally in the .vcxproj.

**Fix**: use sanitizedProjectName for the .vcxproj filename and the .sln/.vcxproj %PROJECTNAME%, and align the two .vcxproj template tokens to {%PROJECTGUID%} / %PROJECTNAME%. The GUI path already worked because it passes a project name.